### PR TITLE
create single model file

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import lkml
 import pathlib
@@ -42,22 +43,30 @@ def generate_lookml_views(models: List[models.MetriqlModel]):
     )
 
 
-def generate_lookml_models(models: List[models.MetriqlModel]):
+def generate_lookml_models(models: List[models.MetriqlModel], project_name: str):
 
-    lookml_models = [
-        generator.lookml_model_from_metriql_model(model, "Project Name")
-        for model in typed_metriql_models
-    ]
+    lookml_models_file = generator.lookml_model_from_metriql_models(
+        models, project_name
+    )
 
-    for model in lookml_models:
-        with open(os.path.join(LOOKML_OUTPUT_DIR, model.filename), "w") as f:
-            f.write(model.contents)
-    logging.info(f"Generated {len(lookml_models)} lookml models in {LOOKML_OUTPUT_DIR}")
+    with open(os.path.join(LOOKML_OUTPUT_DIR, lookml_models_file.filename), "w") as f:
+        f.write(lookml_models_file.contents)
+
+    logging.info(
+        f"Generated {lookml_models_file.filename} lookml models in {LOOKML_OUTPUT_DIR}"
+    )
 
 
 if __name__ == "__main__":
 
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        "--project_name", help="Model name", type=str, default="explorer"
+    )
+
+    args = argparser.parse_args()
+
     typed_metriql_models = load_metriql_models()
     generate_lookml_views(typed_metriql_models)
-    generate_lookml_models(typed_metriql_models)
+    generate_lookml_models(typed_metriql_models, args.project_name)
     logging.info("Success")

--- a/src/generator.py
+++ b/src/generator.py
@@ -1,4 +1,5 @@
 import lkml
+from typing import List
 from models import MetriqlModel, LookViewFile, LookModelFile, Measure
 
 
@@ -15,14 +16,23 @@ def lookml_view_from_metriql_model(model: MetriqlModel):
     return LookViewFile(filename=filename, contents=contents)
 
 
-def lookml_model_from_metriql_model(model: MetriqlModel, dbt_project_name: str):
+def lookml_model_from_metriql_models(models: List[MetriqlModel], project_name: str):
+
+    explore = []
+    for model in models:
+        explore_model_data = {"name": model.name}
+        if model.description:
+            explore_model_data["description"] = model.description
+        explore.append(explore_model_data)
+
     lookml = {
-        "connection": dbt_project_name,
+        "connection": project_name,
         "include": "/views/*",
-        "explore": {"name": model.name, "description": model.description},
+        "explore": explore,
     }
+
     contents = lkml.dump(lookml)
-    filename = f"{model.name}.model"
+    filename = f"{project_name}.model"
     return LookModelFile(filename=filename, contents=contents)
 
 


### PR DESCRIPTION
1. If the description is an empty string, let’s ignore it
2. Rather than creating one model for each dataset, let’s create a single file called explores.model and include all the explores.
3. Here is an example:
```
connection: "Project Name"
include: "/views/*"
explore: source_snowflake_tpch_sample_tpch_orders {
  description: ""
}
explore: source_snowflake_tpch_sample_tpch_customers {
  description: ""
}
```
3. We should probably implement command line arguments for changing the name but the default will be explores 